### PR TITLE
Fix error

### DIFF
--- a/lua/nekokak.lua
+++ b/lua/nekokak.lua
@@ -54,7 +54,7 @@ function Nekokak:start(opts)
       opts.count,
       function(v)
         return type(v) == 'number' and v > 0
-      end
+      end,
       'should be a positive number',
     },
   }


### PR DESCRIPTION
Fix this error.

```
E5108: Error executing lua vim/_init_packages.lua:0: .../repos/github.com/delphinus/nekokak.nvim/lua/nekokak.lua:58: '}' expected (to close '{' at line 53) near ''should be a positive number''                                                                      
stack traceback:
        [C]: in function 'error'
        vim/_init_packages.lua: in function <vim/_init_packages.lua:0>
        [C]: in function 'require'
        [string ":lua"]:1: in main chunk
```